### PR TITLE
fix: add CODEDOV_TOKEN in test-coverage workflow

### DIFF
--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -31,7 +31,8 @@ jobs:
           covr::codecov(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package"),
+            token = Sys.getenv("CODECOV_TOKEN")
           )
         shell: Rscript {0}
 

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -12,6 +12,7 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
     env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:

--- a/examples/test-coverage.yaml
+++ b/examples/test-coverage.yaml
@@ -31,8 +31,7 @@ jobs:
           covr::codecov(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package"),
-            token = Sys.getenv("CODECOV_TOKEN")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
         shell: Rscript {0}
 


### PR DESCRIPTION
- To be able to upload the code coverage result to codecov.io users must now provide a CODECOV_TOKEN to authenticate to the service.
- This token must be defined as a repository secret.
- GITHUB_PAT is no longer required for the workflow to work